### PR TITLE
Added transformation. Removed chord module.

### DIFF
--- a/Brainremin_003.py
+++ b/Brainremin_003.py
@@ -18,10 +18,9 @@ class MuseServer(ServerThread):
 		player = Player() 
 		player.open_stream() 
 		synthesizer = Synthesizer(osc1_waveform = Waveform.sine, osc1_volume = 1.0, use_osc2 = False)
-	
-		chord = [lE-100, lF-100, rF-100, rE-100]
 		number = ra.uniform(0.2, 1.0)
-		player.play_wave(synthesizer.generate_chord(chord, number))
+		player.play_wave(synthesizer.generate_constant_wave((lF - 1200)*((600-200)/(1200-750)) + 200), number)
+		player.play_wave(synthesizer.generate_constant_wave((rF - 1200)*((600-200)/(1200-750)) + 200), number)
 
 try:
     server = MuseServer()


### PR DESCRIPTION
Added affine transformation for mapping average 700-1200 EEG activity unto 200-400hz audio range. Removed chord module, now reproduces waves as standalone waves using only Fp1 and Fp2. Possible migration outside pyliblo suggested for this and other muse-related projects.